### PR TITLE
Add support for multiple git remotes in one repo

### DIFF
--- a/clowder/cmd.py
+++ b/clowder/cmd.py
@@ -171,13 +171,6 @@ def main():
     colorama.init()
     Command()
 
-# Disable errors shown by pylint for unused arguments
-# pylint: disable=W0613
-def signal_handler(sig, frame):
-    """Signal handler for Ctrl+C trap"""
-    print('')
-    sys.exit(0)
-
 def exit_unrecognized_command(parser):
     """Print unrecognized command message and exit"""
     cprint('Unrecognized command\n', 'red')
@@ -189,3 +182,10 @@ def exit_clowder_not_found():
     """Print clowder not found message and exit"""
     print_clowder_not_found_message()
     sys.exit(1)
+
+# Disable errors shown by pylint for unused arguments
+# pylint: disable=W0613
+def signal_handler(sig, frame):
+    """Signal handler for Ctrl+C trap"""
+    print('')
+    sys.exit(0)

--- a/clowder/model/clowder_repo.py
+++ b/clowder/model/clowder_repo.py
@@ -20,7 +20,7 @@ class ClowderRepo(object):
     def breed(self, url):
         """Clone clowder repo from url"""
         print_clowder_repo_status(self.root_directory)
-        git_clone_url_at_path(url, self.clowder_path)
+        git_clone_url_at_path(url, self.clowder_path, 'origin')
         self.symlink_yaml()
 
     def sync(self):

--- a/clowder/model/clowder_repo.py
+++ b/clowder/model/clowder_repo.py
@@ -20,7 +20,7 @@ class ClowderRepo(object):
     def breed(self, url):
         """Clone clowder repo from url"""
         print_clowder_repo_status(self.root_directory)
-        git_clone_url_at_path(url, self.clowder_path, 'origin')
+        git_clone_url_at_path(url, self.clowder_path, 'master', 'origin')
         self.symlink_yaml()
 
     def sync(self):

--- a/clowder/model/clowder_yaml.py
+++ b/clowder/model/clowder_yaml.py
@@ -2,7 +2,7 @@
 import os, sys, yaml
 from termcolor import colored, cprint
 from clowder.model.group import Group
-from clowder.model.remote import Remote
+from clowder.model.source import Source
 from clowder.utility.print_utilities import (
     print_clowder_repo_status,
     print_exiting
@@ -14,8 +14,9 @@ class ClowderYAML(object):
         self.root_directory = rootDirectory
         self.default_ref = None
         self.default_remote = None
+        self.default_source = None
         self.groups = []
-        self.remotes = []
+        self.sources = []
 
         self._load_yaml()
 
@@ -137,14 +138,16 @@ class ClowderYAML(object):
         for group in self.groups:
             groups_yaml.append(group.get_yaml())
 
-        remotes_yaml = []
-        for remote in self.remotes:
-            remotes_yaml.append(remote.get_yaml())
+        sources_yaml = []
+        for source in self.sources:
+            sources_yaml.append(source.get_yaml())
 
-        defaults_yaml = {'ref': self.default_ref, 'remote': self.default_remote}
+        defaults_yaml = {'ref': self.default_ref,
+                         'remote': self.default_remote,
+                         'source': self.default_source}
 
         return {'defaults': defaults_yaml,
-                'remotes': remotes_yaml,
+                'sources': sources_yaml,
                 'groups': groups_yaml}
 
     def _is_dirty(self):
@@ -164,17 +167,20 @@ class ClowderYAML(object):
 
                 self.default_ref = parsed_yaml['defaults']['ref']
                 self.default_remote = parsed_yaml['defaults']['remote']
+                self.default_source = parsed_yaml['defaults']['source']
 
-                for remote in parsed_yaml['remotes']:
-                    self.remotes.append(Remote(remote))
+                for source in parsed_yaml['sources']:
+                    self.sources.append(Source(source))
 
-                defaults = {'ref': self.default_ref, 'remote': self.default_remote}
+                defaults = {'ref': self.default_ref,
+                            'remote': self.default_remote,
+                            'source': self.default_source}
 
                 for group in parsed_yaml['groups']:
                     self.groups.append(Group(self.root_directory,
                                              group,
                                              defaults,
-                                             self.remotes))
+                                             self.sources))
                 # self.groups.sort(key=lambda group: group.name)
 
     def _validate_all(self):

--- a/clowder/model/group.py
+++ b/clowder/model/group.py
@@ -6,11 +6,11 @@ from clowder.utility.print_utilities import print_group
 class Group(object):
     """Model class for clowder.yaml group"""
 
-    def __init__(self, rootDirectory, group, defaults, remotes):
+    def __init__(self, rootDirectory, group, defaults, sources):
         self.name = group['name']
         self.projects = []
         for project in group['projects']:
-            self.projects.append(Project(rootDirectory, project, defaults, remotes))
+            self.projects.append(Project(rootDirectory, project, defaults, sources))
         self.projects.sort(key=lambda project: project.path)
 
     def forall(self, command):
@@ -88,6 +88,7 @@ class Group(object):
         return valid
 
     def _print_name(self):
+        """Print formatted group name"""
         print_group(self.name)
 
     def print_validation(self):

--- a/clowder/model/project.py
+++ b/clowder/model/project.py
@@ -67,15 +67,15 @@ class Project(object):
         """Clone project or update latest from upstream"""
         self._print_status()
         if not os.path.isdir(os.path.join(self.full_path, '.git')):
-            git_clone_url_at_path(self.url, self.full_path)
+            git_clone_url_at_path(self.url, self.full_path, self.remote_name)
         else:
-            git_herd(self.full_path, self.ref)
+            git_herd(self.full_path, self.ref, self.remote_name)
 
     def herd_version(self, version):
         """Check out fixed version of project"""
         self._print_status()
         if not os.path.isdir(os.path.join(self.full_path, '.git')):
-            git_clone_url_at_path(self.url, self.full_path)
+            git_clone_url_at_path(self.url, self.full_path, self.remote_name)
         git_herd_version(self.full_path, version, self.ref)
 
     def is_dirty(self):

--- a/clowder/model/project.py
+++ b/clowder/model/project.py
@@ -66,10 +66,7 @@ class Project(object):
     def herd(self):
         """Clone project or update latest from upstream"""
         self._print_status()
-        if not os.path.isdir(os.path.join(self.full_path, '.git')):
-            git_clone_url_at_path(self.url, self.full_path, self.remote_name)
-        else:
-            git_herd(self.full_path, self.ref, self.remote_name)
+        git_herd(self.full_path, self.ref, self.remote_name, self.url)
 
     def herd_version(self, version):
         """Check out fixed version of project"""

--- a/clowder/model/project.py
+++ b/clowder/model/project.py
@@ -72,7 +72,7 @@ class Project(object):
         """Check out fixed version of project"""
         self._print_status()
         if not os.path.isdir(os.path.join(self.full_path, '.git')):
-            git_clone_url_at_path(self.url, self.full_path, self.remote_name)
+            git_clone_url_at_path(self.url, self.full_path, self.ref, self.remote_name)
         git_herd_version(self.full_path, version, self.ref)
 
     def is_dirty(self):

--- a/clowder/model/project.py
+++ b/clowder/model/project.py
@@ -23,7 +23,7 @@ from clowder.utility.git_utilities import (
 class Project(object):
     """Model class for clowder.yaml project"""
 
-    def __init__(self, root_directory, project, defaults, remotes):
+    def __init__(self, root_directory, project, defaults, sources):
         self.root_directory = root_directory
         self.name = project['name']
         self.path = project['path']
@@ -35,22 +35,27 @@ class Project(object):
             self.ref = defaults['ref']
 
         if 'remote' in project:
-            remote_name = project['remote']
+            self.remote_name = project['remote']
         else:
-            remote_name = defaults['remote']
+            self.remote_name = defaults['remote']
 
-        for remote in remotes:
-            if remote.name == remote_name:
-                self.remote = remote
+        if 'source' in project:
+            source_name = project['source']
+        else:
+            source_name = defaults['source']
 
-        self.remote_url = self.remote.get_url_prefix() + self.name + ".git"
+        for source in sources:
+            if source.name == source_name:
+                self.source = source
+
+        self.url = self.source.get_url_prefix() + self.name + ".git"
 
     def get_yaml(self):
         """Return python object representation for saving yaml"""
         return {'name': self.name,
                 'path': self.path,
                 'ref': git_current_sha(self.full_path),
-                'remote': self.remote.name}
+                'remote': self.source.name}
 
     def groom(self):
         """Discard changes for project"""
@@ -62,7 +67,7 @@ class Project(object):
         """Clone project or update latest from upstream"""
         self._print_status()
         if not os.path.isdir(os.path.join(self.full_path, '.git')):
-            git_clone_url_at_path(self.remote_url, self.full_path)
+            git_clone_url_at_path(self.url, self.full_path)
         else:
             git_herd(self.full_path, self.ref)
 
@@ -70,7 +75,7 @@ class Project(object):
         """Check out fixed version of project"""
         self._print_status()
         if not os.path.isdir(os.path.join(self.full_path, '.git')):
-            git_clone_url_at_path(self.remote_url, self.full_path)
+            git_clone_url_at_path(self.url, self.full_path)
         git_herd_version(self.full_path, version, self.ref)
 
     def is_dirty(self):
@@ -105,6 +110,7 @@ class Project(object):
         return git_validate_repo_state(self.full_path)
 
     def _print_status(self):
+        """Print formatted project status"""
         print_project_status(self.root_directory, self.path, self.name)
 
     def print_validation(self):

--- a/clowder/model/source.py
+++ b/clowder/model/source.py
@@ -1,7 +1,7 @@
-"""Model representation of clowder.yaml remote"""
+"""Model representation of clowder.yaml source"""
 
-class Remote(object):
-    """Model class for clowder.yaml remote"""
+class Source(object):
+    """Model class for clowder.yaml source"""
 
     def __init__(self, remote):
         self.name = remote['name']
@@ -9,12 +9,12 @@ class Remote(object):
 
     def get_url_prefix(self):
         """Return full remote url for project"""
-        remote_url_prefix = None
+        source_url_prefix = None
         if self.url.startswith('https://'):
-            remote_url_prefix = self.url + "/"
+            source_url_prefix = self.url + "/"
         elif self.url.startswith('ssh://'):
-            remote_url_prefix = self.url[6:] + ":"
-        return remote_url_prefix
+            source_url_prefix = self.url[6:] + ":"
+        return source_url_prefix
 
     def get_yaml(self):
         """Return python object representation for saving yaml"""

--- a/clowder/utility/git_utilities.py
+++ b/clowder/utility/git_utilities.py
@@ -27,7 +27,7 @@ def git_clone_url_at_path(url, repo_path, branch, remote):
             default_branch.checkout()
         except:
             pass
-            
+
 def git_current_branch(repo_path):
     """Return currently checked out branch of project"""
     repo = Repo(repo_path)
@@ -95,7 +95,11 @@ def git_herd(repo_path, branch_ref, remote, url):
     else:
         repo = Repo(repo_path)
         git = repo.git
-        git.fetch('--all', '--prune', '--tags')
+        try:
+            git.fetch('--all', '--prune', '--tags')
+        except:
+            print('Failed to fetch')
+            return
         branch_output = colored('(' + branch + ')', 'magenta')
         try:
             repo.remotes[remote]

--- a/clowder/utility/git_utilities.py
+++ b/clowder/utility/git_utilities.py
@@ -99,24 +99,38 @@ def git_herd(repo_path, branch_ref, remote, url):
                 origin = repo.create_remote(remote, url)
         except:
             origin = repo.create_remote(remote, url)
+            print('Failed to create the remote')
+            return
         if git_current_branch(repo_path) is not branch:
-            try:
-                if repo.heads[branch]:
-                    # print(' - Not on default branch.')
+            if repo.heads[branch]:
+                try:
                     print(' - Checkout ' + branch_output)
                     git.checkout(branch)
+                except:
+                    print('Failed to checkout branch')
+                    return
+                try:
                     print(' - Pulling latest changes')
                     print(git.pull(remote, branch))
-            except:
-                # print(' - No existing default branch.')
-                print(' - Create and checkout ' + branch_output)
-                origin = repo.remotes.origin
-                branch = repo.create_head(branch, origin.refs[branch])
-                branch.set_tracking_branch(origin.refs[branch])
-                branch.checkout()
+                except:
+                    print('Failed to pull latest changes')
+                    return
+            else:
+                try:
+                    print(' - Create and checkout ' + branch_output)
+                    origin = repo.remotes[remote]
+                    branch = repo.create_head(branch, origin.refs[branch])
+                    branch.set_tracking_branch(origin.refs[branch])
+                    branch.checkout()
+                except:
+                    print('Failed to create and checkout branch')
+                    return
         else:
             print(' - Pulling latest changes')
-            print(git.pull())
+            try:
+                print(git.pull(remote, branch))
+            except:
+                print('Failed to pull latest changes')
 
 def git_herd_version(repo_path, version, ref):
     """Sync fixed version of repo at path"""

--- a/clowder/utility/git_utilities.py
+++ b/clowder/utility/git_utilities.py
@@ -3,7 +3,10 @@ import os
 from git import Repo
 from termcolor import colored
 
-def git_clone_url_at_path(url, repo_path):
+# Disable errors shown by pylint for unused arguments
+# pylint: disable=W0702
+
+def git_clone_url_at_path(url, repo_path, remote):
     """Clone git repo from url at path"""
     if not os.path.isdir(os.path.join(repo_path, '.git')):
         if not os.path.isdir(repo_path):
@@ -11,7 +14,7 @@ def git_clone_url_at_path(url, repo_path):
         repo_path_output = colored(repo_path, 'cyan')
         print(' - Cloning repo at ' + repo_path_output)
         repo = Repo.init(repo_path)
-        origin = repo.create_remote('origin', url)
+        origin = repo.create_remote(remote, url)
         try:
             origin.fetch()
         except:
@@ -81,27 +84,27 @@ def git_groom(repo_path):
     else:
         print(' - No changes to discard')
 
-def git_herd(repo_path, ref):
+def git_herd(repo_path, branch_ref, remote):
     """Sync git repo with default branch"""
     repo = Repo(repo_path)
     git = repo.git
     git.fetch('--all', '--prune', '--tags')
-    project_ref = git_truncate_ref(ref)
-    branch_output = colored('(' + project_ref + ')', 'magenta')
-    if git_current_branch(repo_path) is not project_ref:
+    branch = git_truncate_ref(branch_ref)
+    branch_output = colored('(' + branch + ')', 'magenta')
+    if git_current_branch(repo_path) is not branch:
         try:
-            if repo.heads[project_ref]:
+            if repo.heads[branch]:
                 # print(' - Not on default branch.')
                 print(' - Checkout ' + branch_output)
-                git.checkout(project_ref)
+                git.checkout(branch)
                 print(' - Pulling latest changes')
-                print(git.pull())
+                print(git.pull(remote, branch))
         except:
             # print(' - No existing default branch.')
             print(' - Create and checkout ' + branch_output)
             origin = repo.remotes.origin
-            branch = repo.create_head(project_ref, origin.refs[project_ref])
-            branch.set_tracking_branch(origin.refs[project_ref])
+            branch = repo.create_head(branch, origin.refs[branch])
+            branch.set_tracking_branch(origin.refs[branch])
             branch.checkout()
     else:
         print(' - Pulling latest changes')

--- a/clowder/utility/git_utilities.py
+++ b/clowder/utility/git_utilities.py
@@ -95,12 +95,10 @@ def git_herd(repo_path, branch_ref, remote, url):
         git.fetch('--all', '--prune', '--tags')
         branch_output = colored('(' + branch + ')', 'magenta')
         try:
-            if not repo.remotes[remote]:
-                origin = repo.create_remote(remote, url)
+            repo.remotes[remote]
         except:
+            print("Remote doesn't exist. Creating remote.")
             origin = repo.create_remote(remote, url)
-            print('Failed to create the remote')
-            return
         if git_current_branch(repo_path) is not branch:
             if repo.heads[branch]:
                 try:

--- a/clowder/utility/git_utilities.py
+++ b/clowder/utility/git_utilities.py
@@ -21,10 +21,13 @@ def git_clone_url_at_path(url, repo_path, branch, remote):
             print(' - Failed to fetch. Removing ' + repo_path_output)
             os.rmdir(repo_path)
             return
-        default_branch = repo.create_head(branch, origin.refs[branch])
-        default_branch.set_tracking_branch(origin.refs[branch])
-        default_branch.checkout()
-
+        try:
+            default_branch = repo.create_head(branch, origin.refs[branch])
+            default_branch.set_tracking_branch(origin.refs[branch])
+            default_branch.checkout()
+        except:
+            pass
+            
 def git_current_branch(repo_path):
     """Return currently checked out branch of project"""
     repo = Repo(repo_path)

--- a/clowder/utility/print_utilities.py
+++ b/clowder/utility/print_utilities.py
@@ -98,7 +98,7 @@ def print_validation(repo_path):
     # if not git_validate_detached(repo_path):
     #     print(' - HEAD is detached. Please point your HEAD to a branch before running clowder')
     if not git_validate_dirty(repo_path):
-        print(' - Repo is dirty. Please stash, commit, or discard your changes before running clowder')
+        print(' - Dirty repo. Please stash, commit, or discard your changes')
     # if not git_validate_untracked(repo_path):
     #     print(' - There are untracked files. Please remove these files or add to .gitignore')
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ if sys.version_info[0] < 3:
 setup(
     name='clowder',
     description='A tool for managing code',
-    version='0.3.1',
+    version='0.4.0',
     url='https://github.com/jrgoodle/clowder',
     author='joe DeCapo',
     author_email='joe@polka.cat',


### PR DESCRIPTION
Changes the concept of a `remote` in the `clowder.yaml` to a `source`. Repurposes `remote` into the concept of a git `remote` so one repo can have multiple remotes specified in the `clowder.yaml`.