### PR TITLE
Consolidate `clowder herd -v` behavior

### DIFF
--- a/clowder/cmd.py
+++ b/clowder/cmd.py
@@ -128,13 +128,10 @@ class Command(object):
             clowder_repo = ClowderRepo(self.root_directory)
             clowder_repo.symlink_yaml(self.args.version)
             clowder = ClowderYAML(self.root_directory)
-            if self.args.version is None:
-                if self.args.groups is None:
-                    clowder.herd_all()
-                else:
-                    clowder.herd_groups(self.args.groups)
+            if self.args.groups is not None:
+                clowder.herd_groups(self.args.groups)
             else:
-                clowder.herd_version(self.args.version)
+                clowder.herd_all()
         else:
             exit_clowder_not_found()
 

--- a/clowder/model/clowder_yaml.py
+++ b/clowder/model/clowder_yaml.py
@@ -104,14 +104,6 @@ class ClowderYAML(object):
             if group.name in group_names:
                 group.herd()
 
-    def herd_version(self, version):
-        """Sync all projects to fixed versions"""
-        self._validate_all()
-        print_clowder_repo_status(self.root_directory)
-        print('')
-        for group in self.groups:
-            group.herd_version(version)
-
     def meow(self):
         """Print status for all projects"""
         print_clowder_repo_status(self.root_directory)

--- a/clowder/model/group.py
+++ b/clowder/model/group.py
@@ -40,12 +40,6 @@ class Group(object):
         for project in self.projects:
             project.herd()
 
-    def herd_version(self, version):
-        """Sync all projects to fixed versions"""
-        self._print_name()
-        for project in self.projects:
-            project.herd_version(version)
-
     def is_dirty(self):
         """Check if group has dirty project(s)"""
         is_dirty = False

--- a/clowder/model/project.py
+++ b/clowder/model/project.py
@@ -11,10 +11,8 @@ from clowder.utility.git_utilities import (
     git_is_dirty
 )
 from clowder.utility.git_utilities import (
-    git_clone_url_at_path,
     git_current_sha,
     git_herd,
-    git_herd_version,
     git_validate_repo_state
 )
 
@@ -70,13 +68,6 @@ class Project(object):
         """Clone project or update latest from upstream"""
         self._print_status()
         git_herd(self.full_path(), self.ref, self.remote_name, self.url)
-
-    def herd_version(self, version):
-        """Check out fixed version of project"""
-        self._print_status()
-        if not os.path.isdir(os.path.join(self.full_path(), '.git')):
-            git_clone_url_at_path(self.url, self.full_path(), self.ref, self.remote_name)
-        git_herd_version(self.full_path(), version, self.ref)
 
     def is_dirty(self):
         """Check if project is dirty"""

--- a/clowder/utility/git_utilities.py
+++ b/clowder/utility/git_utilities.py
@@ -45,19 +45,23 @@ def git_checkout_sha(repo_path, sha):
     """Checkout commit sha"""
     repo = Repo(repo_path)
     ref_output = colored('(' + sha + ')', 'magenta')
-    print(' - Checkout ref ' + ref_output)
-    try:
-        repo.git.checkout(sha)
-    except:
-        print(' - Failed to checkout ref ' + ref_output)
+    if repo.head.commit.hexsha != sha:
+        try:
+            print(' - Checkout ref ' + ref_output)
+            repo.git.checkout(sha)
+        except:
+            print(' - Failed to checkout ref ' + ref_output)
+    else:
+        print(' - Already on correct commit')
 
 def git_checkout_tag(repo_path, tag):
     """Checkout tag"""
     repo = Repo(repo_path)
     tag_output = colored('(' + tag + ')', 'magenta')
-    print(' - Checkout tag ' + tag_output)
     try:
-        repo.git.checkout(tag)
+        if repo.head.ref != repo.tags[tag]:
+            print(' - Checkout tag ' + tag_output)
+            repo.git.checkout(tag)
     except:
         print(' - Failed to checkout tag ' + tag_output)
 
@@ -155,24 +159,6 @@ def git_herd(repo_path, ref, remote, url):
             git_checkout_default_ref(repo_path, ref, remote)
         else:
             print('Unknown ref ' + ref)
-
-def git_herd_version(repo_path, version, ref):
-    """Sync fixed version of repo at path"""
-    repo = Repo(repo_path)
-    branch_output = colored('(' + version + ')', 'magenta')
-    if version in repo.heads:
-        if repo.active_branch is not repo.heads[version]:
-            print(' - Checkout branch ' + branch_output)
-            try:
-                repo.git.checkout(version)
-            except:
-                print(' - Failed to checkout branch ' + branch_output)
-    else:
-        print(' - Create and checkout branch ' + branch_output)
-        try:
-            repo.git.checkout('-b', version, ref)
-        except:
-            print(' - Failed to create and checkout branch ' + branch_output)
 
 def git_has_untracked_files(repo_path):
     """Check if there are untracked files"""

--- a/clowder/utility/git_utilities.py
+++ b/clowder/utility/git_utilities.py
@@ -45,14 +45,16 @@ def git_checkout_sha(repo_path, sha):
     """Checkout commit sha"""
     repo = Repo(repo_path)
     ref_output = colored('(' + sha + ')', 'magenta')
-    if repo.head.commit.hexsha != sha:
+    try:
+        if repo.head.commit.hexsha == sha:
+            print(' - Already on correct commit')
+            return
+    except:
+        print(' - Checkout ref ' + ref_output)
         try:
-            print(' - Checkout ref ' + ref_output)
             repo.git.checkout(sha)
         except:
             print(' - Failed to checkout ref ' + ref_output)
-    else:
-        print(' - Already on correct commit')
 
 def git_checkout_tag(repo_path, tag):
     """Checkout tag"""

--- a/scripts/test_cats_example.sh
+++ b/scripts/test_cats_example.sh
@@ -49,6 +49,7 @@ echo "TEST: Herd version after breed"
 ./breed.sh || exit 1
 clowder herd -v v0.1 || exit 1
 clowder meow || exit 1
+clowder forall -c 'git checkout -b v0.1'
 
 echo "TEST: Check current branches"
 for project in "${projects[@]}"

--- a/scripts/test_llvm_projects_example.sh
+++ b/scripts/test_llvm_projects_example.sh
@@ -87,6 +87,7 @@ print_separator
 echo "TEST: Herd a previously fixed version"
 clowder herd -v v0.1 || exit 1
 clowder meow || exit 1
+clowder forall -c 'git checkout -b v0.1'
 
 echo "TEST: Check current branches"
 for project in "${projects[@]}"

--- a/scripts/test_srclib_example.sh
+++ b/scripts/test_srclib_example.sh
@@ -57,6 +57,7 @@ echo "TEST: Herd version after breed"
 ./breed.sh || exit 1
 clowder herd -v v0.1 || exit 1
 clowder meow || exit 1
+clowder forall -c 'git checkout -b v0.1'
 
 echo "TEST: Check current branches"
 for project in "${projects[@]}"


### PR DESCRIPTION
Don't create branches when herding a version. Just checkout refs. Update test scripts appropriately.