### PR TITLE
Remove `clowder sync` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Managing multiple repositories can be pretty frustrating. There are a number of 
 
 All of these have their own approach, but many are based on submodules or subtrees. Submodules and subtrees create a tight coupling between repositories because of the way dependencies are stored. Much has been written about their drawbacks elsewhere. Google's `repo` tool takes a different approach, but is closely tied to Google's development workflow.
 
-`clowder` uses a similar approach as `repo` (and as it turns out, `gr` and `giternal`) with a yaml file instead of xml. URL information and relative project locations on disk are specified in a `clowder.yaml` file. This file is checked into its own repository (which at this point assumes one branch due to the way saved versions are handled). The use of a separate file for tracking projects means that there's detailed information about the dependencies between them, but each repository is still essentially independent. Projects can be tied to specific tags or commits, or can track branches. Specific versions can be saved from the current commit hashes of projects on disk for later restoration.
+`clowder` uses a similar approach as `repo` (and as it turns out, `gr` and `giternal`) with a yaml file instead of xml. URL information and relative project locations on disk are specified in a `clowder.yaml` file. This file is checked into its own repository (which at this point assumes one branch due to the way saved versions are handled). The use of a separate file for tracking projects means that there's detailed information about the dependencies between them, but each repository is still essentially independent. Projects can be tied to specific tags or commits, or can track branches. With the `clowder fix <version>` command, specific versions of the `clowder.yaml` file can be saved from the current commit hashes of all projects for later restoration.
 
 The primary purpose of `clowder` is synchronization of multiple repositories, so normal development still takes place in individual repositories with the usual `git` commands.
 
@@ -37,7 +37,7 @@ For a few example projects, see the [examples directory](https://github.com/JrGo
 To install from the [GitHub Releases](https://github.com/JrGoodle/clowder/releases), first download the latest `.whl` file, then:
 
 ```bash
-$ pip3 install clowder-0.8.0-py3-none-any.whl
+$ pip3 install clowder-0.8.1-py3-none-any.whl
 ```
 
 To install from the cloned repository:
@@ -69,19 +69,19 @@ Clone repository containing `clowder.yaml` file.
 $ clowder breed https://github.com/jrgoodle/llvm-projects.git
 ```
 
-The `clowder breed` command will clone the [llvm-projects](https://github.com/jrgoodle/llvm-projects.git) repository in the `llvm-projects/.clowder` directory and create a symlink pointing to the primary `clowder.yaml` file in the repository: `llvm-projects/clowder.yaml` -> `llvm-projects/.clowder/clowder.yaml`.
+The `clowder breed` command will clone the [llvm-projects](https://github.com/jrgoodle/llvm-projects.git) repository in the `llvm-projects/.clowder` directory and create a symlink pointing to the primary `clowder.yaml` file in the repository:
+
+```
+llvm-projects/clowder.yaml -> llvm-projects/.clowder/clowder.yaml
+```
+
+Next sync (`herd`) all repositories:
 
 ```bash
 $ clowder herd
 ```
 
 The `clowder herd` command syncs the projects. The `clowder.yaml` symlink is always updated to point to the primary `clowder.yaml` file in the repository cloned with `clowder breed`. Projects are cloned if they don't currently exist. Otherwise, each project will pull the latest changes. If the current branch isn't the default, it'll be checked out, and latest changes pulled. For commits and tags, the commits are checked out into a detached HEAD state (`clowder forall` can be used to checkout branches if needed).
-
-```bash
-$ clowder sync
-```
-
-The `clowder sync` command is like `clowder herd`, but for syncing the repository containing the `clowder.yaml` file (located in the `.clowder` directory created with the `clowder breed` command). It will try to pull latest changes for whatever branch is currently checked out in the `.clowder` directory. If the repository is in a detached HEAD state, a message will be printed indicating this, and the command will exit without trying to pull any new changes.
 
 ### Further Commands
 

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ Managing multiple repositories can be pretty frustrating. There are a number of 
 - [git-stree](https://github.com/tdd/git-stree)
 - [git-subrepo](https://github.com/ingydotnet/git-subrepo)
 
-All of these have their own approach, but many are based on submodules or subtrees. Submodules and subtrees create a tight coupling between repositories because of the way dependencies are stored. Much has been written about their drawbacks elsewhere. Google's `repo` tool takes a different approach, but is closely tied to Google's development workflow (and doesn't have a great deal of documentation).
+All of these have their own approach, but many are based on submodules or subtrees. Submodules and subtrees create a tight coupling between repositories because of the way dependencies are stored. Much has been written about their drawbacks elsewhere. Google's `repo` tool takes a different approach, but is closely tied to Google's development workflow.
 
-`clowder` uses a similar approach as `repo` (and as it turns out, `gr` and `giternal`) with a yaml file instead of xml (and without the default rebasing behavior of `repo`). URL information and relative project locations on disk are specified in a `clowder.yaml` file. This file is checked into its own repository, so the project structure's history is saved under version control. The use of a separate file for tracking projects means that there's detailed information about the dependencies between them, but each repository is still essentially independent. Projects can be tied to specific tags or commits, or can track branches. Specific versions can be saved from the current commit hashes of projects on disk for later restoration.
+`clowder` uses a similar approach as `repo` (and as it turns out, `gr` and `giternal`) with a yaml file instead of xml. URL information and relative project locations on disk are specified in a `clowder.yaml` file. This file is checked into its own repository (which at this point assumes one branch due to the way saved versions are handled). The use of a separate file for tracking projects means that there's detailed information about the dependencies between them, but each repository is still essentially independent. Projects can be tied to specific tags or commits, or can track branches. Specific versions can be saved from the current commit hashes of projects on disk for later restoration.
 
 The primary purpose of `clowder` is synchronization of multiple repositories, so normal development still takes place in individual repositories with the usual `git` commands.
 
@@ -86,7 +86,7 @@ The `clowder sync` command is like `clowder herd`, but for syncing the repositor
 ### Further Commands
 
 ```bash
-$ clowder fix v0.1 # Fix new version of clowder.yaml
+$ clowder fix v0.1 # Save a fixed version of clowder.yaml
 ```
 
 ```bash
@@ -119,10 +119,6 @@ $ clowder meow -v -g clang # print verbose status of projects in clang group
 $ clowder stash # Stash any changes in projects
 $ clowder stash -g clang # Stash any changes in projects in clang group
 $ clowder stash -p llvm-mirror/clang # Stash any changes in clang project
-```
-
-```bash
-$ clowder sync -b alternate-yaml # Sync clowder.yaml repo with alternate local branch
 ```
 
 ## The `clowder.yaml` File

--- a/clowder/clowder_controller.py
+++ b/clowder/clowder_controller.py
@@ -1,12 +1,11 @@
 """clowder.yaml parsing and functionality"""
-import os, yaml
+import os, yaml, sys
 from termcolor import colored
 from clowder.group import Group
 from clowder.source import Source
 from clowder.utility.clowder_utilities import (
     forall_run,
-    validate_yaml,
-    print_exiting
+    validate_yaml
 )
 
 class ClowderController(object):
@@ -40,7 +39,7 @@ class ClowderController(object):
                 yaml.dump(self._get_yaml(), file, default_flow_style=False)
         else:
             print('Version ' + version_output + ' already exists at ' + yaml_file_output)
-            print_exiting()
+            sys.exit(1)
 
     def forall_groups(self, command, group_names):
         """Runs command in all project directories of groups specified"""
@@ -194,7 +193,7 @@ class ClowderController(object):
                 if not group.is_valid():
                     valid = False
         if not valid:
-            print_exiting()
+            sys.exit(1)
 
     def _validate_projects_exist(self):
         """Validate existence status of all projects for specified groups"""
@@ -207,4 +206,4 @@ class ClowderController(object):
             herd_output = colored('clowder herd', 'yellow')
             print('')
             print('First run ' + herd_output + ' to clone missing projects')
-            print_exiting()
+            sys.exit(1)

--- a/clowder/clowder_repo.py
+++ b/clowder/clowder_repo.py
@@ -1,5 +1,5 @@
 """Clowder repo management"""
-import emoji, os
+import emoji, os, sys
 # from git import Repo
 from termcolor import colored
 from clowder.utility.git_utilities import (
@@ -10,7 +10,6 @@ from clowder.utility.clowder_utilities import (
     force_symlink,
     format_project_string,
     format_ref_string,
-    print_exiting,
     print_validation,
     validate_repo_state
 )
@@ -58,10 +57,10 @@ class ClowderRepo(object):
             force_symlink(yaml_file, yaml_symlink)
         else:
             print(path_output + " doesn't seem to exist")
-            print_exiting()
+            sys.exit(1)
 
     def _validate(self):
         """Validate status of clowder repo"""
         if not validate_repo_state(self.clowder_path):
             print_validation(self.clowder_path)
-            print_exiting()
+            sys.exit(1)

--- a/clowder/clowder_repo.py
+++ b/clowder/clowder_repo.py
@@ -1,12 +1,10 @@
 """Clowder repo management"""
 import emoji, os
-from git import Repo
+# from git import Repo
 from termcolor import colored
 from clowder.utility.git_utilities import (
     git_branches,
-    git_clone_url_at_path,
-    git_is_detached,
-    git_pull
+    git_clone_url_at_path
 )
 from clowder.utility.clowder_utilities import (
     force_symlink,
@@ -61,46 +59,6 @@ class ClowderRepo(object):
         else:
             print(path_output + " doesn't seem to exist")
             print_exiting()
-
-    def sync(self):
-        """Sync clowder repo"""
-        self._validate()
-        self.print_status()
-        if not git_is_detached(self.clowder_path):
-            git_pull(self.clowder_path)
-            self.symlink_yaml()
-        else:
-            print(' - HEAD is detached')
-            print_exiting()
-
-    # Disable errors shown by pylint for no specified exception types
-    # pylint: disable=W0702
-    def sync_branch(self, branch):
-        """Sync clowder repo to specified branch"""
-        try:
-            repo = Repo(self.clowder_path)
-        except:
-            repo_path_output = colored(self.clowder_path, 'cyan')
-            print("Failed to create Repo instance for " + repo_path_output)
-        else:
-            if git_is_detached(self.clowder_path):
-                try:
-                    repo.git.checkout(branch)
-                except:
-                    print("Failed to checkout branch " + branch)
-                    print_exiting()
-
-            if repo.active_branch.name != branch:
-                try:
-                    repo.git.checkout(branch)
-                except:
-                    print("Failed to checkout branch " + branch)
-                    print_exiting()
-
-            self._validate()
-            self.print_status()
-            git_pull(self.clowder_path)
-            self.symlink_yaml()
 
     def _validate(self):
         """Validate status of clowder repo"""

--- a/clowder/cmd.py
+++ b/clowder/cmd.py
@@ -8,7 +8,6 @@ import argcomplete, argparse, colorama, os, signal, sys
 from termcolor import cprint
 from clowder.clowder_repo import ClowderRepo
 from clowder.clowder_controller import ClowderController
-from clowder.utility.clowder_utilities import print_exiting
 
 class Command(object):
     """Command class for parsing commandline options"""
@@ -58,7 +57,7 @@ class Command(object):
             clowder_repo = ClowderRepo(self.root_directory)
             clowder_repo.breed(self.args.url)
         else:
-            cprint('Clowder already bred in this directory, exiting...\n', 'red')
+            cprint('Clowder already bred in this directory', 'red')
             sys.exit()
 
     def fix(self):
@@ -201,12 +200,12 @@ def exit_unrecognized_command(parser):
     """Print unrecognized command message and exit"""
     cprint('Unrecognized command\n', 'red')
     parser.print_help()
-    print_exiting()
+    sys.exit(1)
 
 def exit_clowder_not_found():
     """Print clowder not found message and exit"""
-    cprint('No clowder found in the current directory, exiting...\n', 'red')
-    print_exiting()
+    cprint('No clowder found in the current directory\n', 'red')
+    sys.exit(1)
 
 def main():
     """Main entrypoint for clowder command"""

--- a/clowder/cmd.py
+++ b/clowder/cmd.py
@@ -139,17 +139,6 @@ class Command(object):
         else:
             exit_clowder_not_found()
 
-    def sync(self):
-        """clowder sync command"""
-        if self.clowder_repo is not None:
-            cprint('Sync...\n', 'yellow')
-            if self.args.branch is None:
-                self.clowder_repo.sync()
-            else:
-                self.clowder_repo.sync_branch(self.args.branch)
-        else:
-            exit_clowder_not_found()
-
 # Disable errors shown by pylint for unused arguments
 # pylint: disable=R0914
     def _configure_subparsers(self, subparsers):
@@ -207,10 +196,6 @@ class Command(object):
                                  help='Groups to stash')
         group_stash.add_argument('--projects', '-p', choices=self.project_names,
                                  nargs='+', help='Projects to stash')
-        # clowder sync
-        parser_sync = subparsers.add_parser('sync', add_help=False, help='Sync clowder repo')
-        parser_sync.add_argument('--branch', '-b', choices=self.branches,
-                                 help='Groups to print status for')
 
 def exit_unrecognized_command(parser):
     """Print unrecognized command message and exit"""

--- a/clowder/project.py
+++ b/clowder/project.py
@@ -140,5 +140,5 @@ class Project(object):
             return
         project_output = format_project_string(repo_path, self.name)
         current_ref_output = format_ref_string(repo_path)
-        path_output = colored(self.path, 'cyan')
-        print(project_output + ' ' + current_ref_output + ' ' + path_output)
+        print(project_output + ' ' + current_ref_output)
+        cprint(self.path, 'cyan')

--- a/clowder/utility/clowder_utilities.py
+++ b/clowder/utility/clowder_utilities.py
@@ -1,6 +1,6 @@
 """Clowder utilities"""
 import errno, os, subprocess, sys
-from termcolor import colored, cprint
+from termcolor import colored
 from clowder.utility.git_utilities import (
     git_current_branch,
     git_current_sha,
@@ -58,13 +58,6 @@ def print_exists(repo_path):
     if not os.path.isdir(os.path.join(repo_path, '.git')):
         print(' - Project is missing')
 
-def print_exiting():
-    """Print Exiting and exit with error code"""
-    print('')
-    cprint('Exiting...', 'red')
-    print('')
-    sys.exit(1)
-
 def print_validation(repo_path):
     """Print validation messages"""
     if not os.path.isdir(os.path.join(repo_path, '.git')):
@@ -102,4 +95,4 @@ def validate_yaml(parsed_yaml):
         print('')
         clowder_output = colored('clowder.yaml', 'cyan')
         print(clowder_output + ' appears to be invalid')
-        print_exiting()
+        sys.exit(1)

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -2,7 +2,7 @@
 
 cd "$( dirname "${BASH_SOURCE[0]}" )"
 
-echo "deploy-ios.sh"
+echo "deploy.sh"
 
 if [[ "$TRAVIS_PULL_REQUEST" != "false" ]]; then
   echo "This is a pull request. No deployment will be done."

--- a/scripts/test_cats_example.sh
+++ b/scripts/test_cats_example.sh
@@ -4,9 +4,9 @@
 
 echo 'TEST: cats example test script'
 
-cd "$( dirname "${BASH_SOURCE[0]}" )"
+cd "$( dirname "${BASH_SOURCE[0]}" )" || exit 1
 source test_utilities.sh
-cd ../examples/cats
+cd ../examples/cats || exit 1
 
 test_branches()
 {
@@ -100,25 +100,6 @@ test_no_versions()
     popd &>/dev/null
 }
 
-test_sync_branch()
-{
-    print_separator
-    echo "TEST: Test syncing branch from current branch"
-    pushd .clowder &>/dev/null
-    git checkout master
-    popd &>/dev/null
-    clowder sync -b master || exit 1
-    echo "TEST: Test syncing other branch"
-    clowder sync -b tags || exit 1
-    echo "TEST: Test syncing missing branch"
-    clowder sync -b sync-missing-branch && exit 1
-    echo "TEST: Test syncing branch from detached HEAD"
-    pushd .clowder &>/dev/null
-    git checkout master~2
-    popd &>/dev/null
-    clowder sync -b master || exit 1
-}
-
 # export projects=( 'black-cats/kit' \
 #                   'black-cats/kishka' \
 #                   'black-cats/sasha' \
@@ -146,7 +127,6 @@ test_groom_missing_directories 'mu' 'duke'
 test_herd_dirty_repos
 test_herd_detached_heads
 test_herd 'duke' 'mu'
-test_sync
 test_forall 'cats'
 test_forall_projects 'jrgoodle/kit' 'jrgoodle/kishka'
 test_fix
@@ -163,6 +143,5 @@ test_invalid_yaml
 test_herd_sha
 test_herd_tag
 test_herd_missing_groups
-test_sync_branch
 
 print_help

--- a/scripts/test_llvm_example.sh
+++ b/scripts/test_llvm_example.sh
@@ -4,9 +4,9 @@
 
 echo 'TEST: llvm projects example test script'
 
-cd "$( dirname "${BASH_SOURCE[0]}" )"
+cd "$( dirname "${BASH_SOURCE[0]}" )" || exit 1
 source test_utilities.sh
-cd ../examples/llvm-projects
+cd ../examples/llvm-projects || exit 1
 
 setup_old_repos()
 {
@@ -74,7 +74,6 @@ test_herd_dirty_repos
 test_groom 'clang' 'llvm'
 test_groom_projects 'llvm-mirror/clang'
 test_groom_missing_directories 'zorg'
-test_sync
 test_herd_detached_heads
 test_forall 'clang' 'llvm'
 test_forall_projects 'llvm-mirror/clang' 'llvm-mirror/llvm'

--- a/scripts/test_srclib_example.sh
+++ b/scripts/test_srclib_example.sh
@@ -4,9 +4,9 @@
 
 echo 'TEST: srclib example test script'
 
-cd "$( dirname "${BASH_SOURCE[0]}" )"
+cd "$( dirname "${BASH_SOURCE[0]}" )" || exit 1
 source test_utilities.sh
-cd ../examples/srclib
+cd ../examples/srclib || exit 1
 
 test_herd_missing_branches()
 {
@@ -59,7 +59,6 @@ test_groom_projects 'sourcegraph/srclib'
 test_herd_dirty_repos
 test_herd_detached_heads
 test_herd 'srclib' 'srcco'
-test_sync
 test_forall 'srclib' 'projects'
 test_forall_projects 'sourcegraph/srclib'
 test_fix

--- a/scripts/test_utilities.sh
+++ b/scripts/test_utilities.sh
@@ -252,30 +252,6 @@ test_stash_projects()
     clowder meow || exit 1
 }
 
-test_sync()
-{
-    print_separator
-    make_dirty_clowder_repo
-    echo "TEST: Fail sync with dirty clowder repo"
-    clowder sync && exit 1
-    echo "TEST: Discard changes in clowder repo"
-    pushd .clowder &>/dev/null
-    git reset --hard
-    popd &>/dev/null
-    echo "TEST: Successfully sync after discarding changes"
-    clowder sync || exit 1
-    echo "TEST: Successfully sync twice"
-    clowder sync || exit 1
-    echo "TEST: Fail sync with detached HEAD in clowder repo"
-    pushd .clowder &>/dev/null
-    git checkout master~2
-    popd &>/dev/null
-    clowder sync && exit 1
-    pushd .clowder &>/dev/null
-    git checkout master
-    popd &>/dev/null
-}
-
 test_herd_groups()
 {
     print_separator


### PR DESCRIPTION
Will later add back as `clowder repo <subcommand>` (see #86)

Making this change now based on the new assumption of only one branch in a repo containing the `clowder.yaml` file (`clowder sync -b` no longer makes sense).