### PR TITLE
Update `clowder status` output

### DIFF
--- a/clowder/clowder_controller.py
+++ b/clowder/clowder_controller.py
@@ -108,6 +108,10 @@ class ClowderController(object):
         """Returns all project names for current clowder.yaml"""
         return sorted([p.name for g in self.groups for p in g.projects])
 
+    def get_all_project_paths(self):
+        """Returns all project paths for current clowder.yaml"""
+        return sorted([p.formatted_project_path() for g in self.groups for p in g.projects])
+
     def get_saved_version_names(self):
         """Return list of all saved versions"""
         versions_dir = os.path.join(self.root_directory, '.clowder', 'versions')
@@ -275,14 +279,14 @@ class ClowderController(object):
         else:
             print('No changes to stash')
 
-    def status_groups(self, group_names, verbose=False):
+    def status_groups(self, group_names, padding, verbose=False):
         """Print status for groups"""
         for group in self.groups:
             if group.name in group_names:
                 if verbose is False:
-                    group.status()
+                    group.status(padding)
                 else:
-                    group.status_verbose()
+                    group.status_verbose(padding)
 
     def status_projects(self, project_names, verbose=False):
         """Print status for projects"""

--- a/clowder/clowder_repo.py
+++ b/clowder/clowder_repo.py
@@ -128,9 +128,9 @@ class ClowderRepo(object):
             real_path = os.path.realpath(clowder_symlink)
             clowder_path = remove_prefix(real_path + '/', self.root_directory)
             path_output = format_path(clowder_path[1:-1])
-            print(project_output + ' ' + current_ref_output + ' ~~> ' + path_output)
+            print(current_ref_output + ' ' + project_output + ' -> ' + path_output)
         else:
-            print(project_output + ' ' + current_ref_output)
+            print(current_ref_output + ' ' + project_output)
 
     def pull(self):
         """Pull clowder repo upstream changes"""

--- a/clowder/cmd.py
+++ b/clowder/cmd.py
@@ -10,6 +10,7 @@ import colorama
 from termcolor import cprint, colored
 from clowder.clowder_repo import ClowderRepo
 from clowder.clowder_controller import ClowderController
+from clowder.utility.git_print_utilities import format_project_string
 
 if __name__ == '__main__':
     raise SystemExit(main())
@@ -363,15 +364,10 @@ class Command(object):
             if self.args.fetch:
                 print(' - Fetch upstream changes for projects')
                 print()
-                if self.args.projects is None:
-                    self.clowder.fetch_groups(self.args.groups)
-                else:
-                    self.clowder.fetch_projects(self.args.projects)
-                print()
-            if self.args.projects is None:
-                self.clowder.status_groups(self.args.groups)
-            else:
-                self.clowder.status_projects(self.args.projects)
+                self.clowder.fetch_groups(self.group_names)
+            all_project_paths = self.clowder.get_all_project_paths()
+            padding = len(max(all_project_paths, key=len))
+            self.clowder.status_groups(self.group_names, padding)
         else:
             exit_clowder_not_found()
 
@@ -666,28 +662,6 @@ class Command(object):
         parser_status = subparsers.add_parser('status', help='Print project status')
         parser_status.add_argument('--fetch', '-f', action='store_true',
                                    help='fetch projects before printing status')
-        if self.group_names is not '':
-            status_help_groups = '''
-                                 groups to print status for:
-                                 {0}
-                                 '''
-            status_help_groups = status_help_groups.format(', '.join(self.group_names))
-        else:
-            status_help_groups = 'groups to print status for'
-        group_status = parser_status.add_mutually_exclusive_group()
-        group_status.add_argument('--groups', '-g', choices=self.group_names,
-                                  default=self.group_names, nargs='+',
-                                  help=status_help_groups, metavar='GROUP')
-        if self.project_names is not '':
-            status_help_projects = '''
-                                   projects to print status for:
-                                   {0}
-                                   '''
-            status_help_projects = status_help_projects.format(', '.join(self.project_names))
-        else:
-            status_help_projects = 'projects to print status for'
-        group_status.add_argument('--projects', '-p', choices=self.project_names,
-                                  nargs='+', help=status_help_projects, metavar='PROJECT')
 
     def _exit_handler_formatter(self):
         """Exit handler to display trailing newline"""

--- a/clowder/group.py
+++ b/clowder/group.py
@@ -114,11 +114,11 @@ class Group(object):
         for project in self.projects:
             project.start(branch, tracking)
 
-    def status(self):
+    def status(self, padding):
         """Print status for all projects"""
         self._print_name()
         for project in self.projects:
-            project.status()
+            project.status(padding)
 
     def stash(self):
         """Stash changes for all projects with changes"""

--- a/clowder/project.py
+++ b/clowder/project.py
@@ -122,6 +122,11 @@ class Project(object):
         if self.exists():
             git_fetch_silent(self.full_path())
 
+    def formatted_project_path(self):
+        """Return formatted project path"""
+        repo_path = os.path.join(self.root_directory, self.path)
+        return format_project_string(repo_path, self.path)
+
     def full_path(self):
         """Return full path to project"""
         return os.path.join(self.root_directory, self.path)
@@ -229,9 +234,9 @@ class Project(object):
         else:
             git_start(self.full_path(), self.remote_name, branch, self.depth, tracking)
 
-    def status(self):
+    def status(self, padding):
         """Print status for project"""
-        self._print_status()
+        self._print_status_indented(padding)
 
     def stash(self):
         """Stash changes for project if dirty"""
@@ -264,3 +269,14 @@ class Project(object):
                 print(short_output)
         except:
             print(long_output)
+
+    def _print_status_indented(self, padding):
+        """Print formatted and indented project status"""
+        repo_path = os.path.join(self.root_directory, self.path)
+        if not git_existing_repository(repo_path):
+            cprint(self.name, 'green')
+            return
+        project_output = format_project_string(repo_path, self.path)
+        current_ref_output = format_project_ref_string(repo_path)
+        path_output = format_path(self.path)
+        print('{0} {1}'.format(project_output.ljust(padding), current_ref_output))

--- a/clowder/utility/git_print_utilities.py
+++ b/clowder/utility/git_print_utilities.py
@@ -31,7 +31,7 @@ def format_project_ref_string(repo_path):
     else:
         local_commits_output = colored('+' + str(local_commits), 'yellow')
         upstream_commits_output = colored('-' + str(upstream_commits), 'red')
-        status = ' (' + local_commits_output + '/' + upstream_commits_output + ')'
+        status = '[' + local_commits_output + '/' + upstream_commits_output + ']'
 
     if git_is_detached(repo_path):
         current_ref = git_sha_short(repo_path)

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -246,10 +246,4 @@ $ clowder status
 
 # Fetch upstream changes for projects before printing statuses
 $ clowder status -f
-
-# Print status of projects in clang and llvm groups
-$ clowder status -g clang llvm
-
-# Print status of clang and llvm projects
-$ clowder status -p llvm-mirror/clang llvm-mirror/llvm
 ```

--- a/script/tests/test_cats_status.sh
+++ b/script/tests/test_cats_status.sh
@@ -9,20 +9,16 @@ cd "$CATS_EXAMPLE_DIR" || exit 1
 print_double_separator
 echo "TEST: Test clowder status"
 
-test_status_groups() {
+test_status() {
     print_single_separator
-    echo "TEST: Test status for specific groups"
-    clowder status -g "$@" || exit 1
-    echo "TEST: Test status for specific groups with fetching"
-    clowder status -f -g "$@" || exit 1
+    echo "TEST: Test status"
+    clowder status -f || exit 1
 }
-test_status_groups 'black-cats'
+test_status
 
-test_status_projects() {
+test_status_fetch() {
     print_single_separator
-    echo "TEST: Test status for specific projects"
-    clowder status -p "$@" || exit 1
-    echo "TEST: Test status for specific projects with fetching"
-    clowder status -f -p "$@" || exit 1
+    echo "TEST: Test status with fetching"
+    clowder status -f || exit 1
 }
-test_status_projects 'jrgoodle/mu' 'jrgoodle/duke'
+test_status_fetch


### PR DESCRIPTION
Remove `-p` and `-g` options. Only display local path on disk. Use indentation for branch display.

resolves #229 