### PR TITLE
Clowder docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+############################################################
+# Dockerfile for clowder project
+# Based on python:3.4.7-wheezy
+############################################################
+FROM python:3.4.7-wheezy
+
+# File Author / Maintainer
+LABEL maintainer "John Lane <john.lane93@gmail.com>"
+
+############################################################
+
+# ensure local python is preferred over distribution python
+ENV PATH /usr/local/bin:$PATH
+
+# http://bugs.python.org/issue19846
+# > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
+ENV LANG C.UTF-8
+
+############################################################
+
+ADD . /src
+
+############################################################
+
+# Install GIT
+RUN apt-get update -y && apt-get install python-dev -y
+
+############################################################
+
+WORKDIR /src
+RUN pip install -e .
+CMD ["/bin/bash"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '3'
+
+services:
+
+  clowder:
+    build: .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+argcomplete==1.9.2
+colorama==0.3.9
+GitPython==2.1.7
+PyYAML==3.12
+termcolor==1.1.0


### PR DESCRIPTION
Initial setup for Docker. Eventually we can create several versions that we can use to test various versions of git and run tests in a sand-boxed environment.
