### PR TITLE
Add the ability to pass arguments to forall scripts

### DIFF
--- a/clowder/clowder/cli/forall_controller.py
+++ b/clowder/clowder/cli/forall_controller.py
@@ -28,7 +28,7 @@ class ForallController(ArgparseController):
     @expose(
         help='Run command or script in project directories',
         arguments=[
-            (['--command', '-c'], dict(nargs=1, metavar='COMMAND',
+            (['--command', '-c'], dict(nargs='+', metavar='COMMAND',
                                        help='command or script to run in project directories')),
             (['--ignore-errors', '-i'], dict(action='store_true', help='ignore errors in command or script')),
             (['--parallel'], dict(action='store_true', help='run commands in parallel')),
@@ -57,6 +57,6 @@ class ForallController(ArgparseController):
     def _forall(self):
         """Clowder forall command private implementation"""
 
-        forall(CLOWDER_CONTROLLER, self.app.pargs.command[0], self.app.pargs.ignore_errors,
+        forall(CLOWDER_CONTROLLER, self.app.pargs.command, self.app.pargs.ignore_errors,
                group_names=self.app.pargs.groups, project_names=self.app.pargs.projects,
                skip=self.app.pargs.skip, parallel=self.app.pargs.parallel)

--- a/clowder/clowder/cli/forall_controller.py
+++ b/clowder/clowder/cli/forall_controller.py
@@ -5,10 +5,16 @@
 
 """
 
+import sys
+
 from cement.ext.ext_argparse import ArgparseController, expose
+from termcolor import cprint
 
 from clowder.cli.globals import CLOWDER_CONTROLLER
-from clowder.cli.parallel import forall
+from clowder.cli.parallel import (
+    forall_command,
+    forall_script
+)
 from clowder.cli.util import options_help_message
 from clowder.clowder_repo import print_clowder_repo_status
 from clowder.util.decorators import valid_clowder_yaml_required
@@ -28,8 +34,10 @@ class ForallController(ArgparseController):
     @expose(
         help='Run command or script in project directories',
         arguments=[
-            (['--command', '-c'], dict(nargs='+', metavar='COMMAND',
-                                       help='command or script to run in project directories')),
+            (['--command', '-c'], dict(nargs='+', metavar='COMMAND', default=None,
+                                       help='command(s) to run in project directories')),
+            (['--file', '-f'], dict(nargs='+', metavar='SCRIPT', default=None,
+                                    help='script to run in project directories')),
             (['--ignore-errors', '-i'], dict(action='store_true', help='ignore errors in command or script')),
             (['--parallel'], dict(action='store_true', help='run commands in parallel')),
             (['--groups', '-g'], dict(choices=CLOWDER_CONTROLLER.get_all_group_names(),
@@ -57,6 +65,18 @@ class ForallController(ArgparseController):
     def _forall(self):
         """Clowder forall command private implementation"""
 
-        forall(CLOWDER_CONTROLLER, self.app.pargs.command, self.app.pargs.ignore_errors,
-               group_names=self.app.pargs.groups, project_names=self.app.pargs.projects,
-               skip=self.app.pargs.skip, parallel=self.app.pargs.parallel)
+        if self.app.pargs.command is not None:
+            forall_command(CLOWDER_CONTROLLER, self.app.pargs.command, self.app.pargs.ignore_errors,
+                           group_names=self.app.pargs.groups, project_names=self.app.pargs.projects,
+                           skip=self.app.pargs.skip, parallel=self.app.pargs.parallel)
+            return
+
+        if self.app.pargs.file is not None:
+            forall_script(CLOWDER_CONTROLLER, self.app.pargs.file, self.app.pargs.ignore_errors,
+                          group_names=self.app.pargs.groups, project_names=self.app.pargs.projects,
+                          skip=self.app.pargs.skip, parallel=self.app.pargs.parallel)
+            return
+
+        cprint(' - Missing --command/-c or --file/-f argument')
+        sys.exit(1)
+

--- a/clowder/clowder/cli/forall_controller.py
+++ b/clowder/clowder/cli/forall_controller.py
@@ -36,8 +36,8 @@ class ForallController(ArgparseController):
         arguments=[
             (['--command', '-c'], dict(nargs='+', metavar='COMMAND', default=None,
                                        help='command(s) to run in project directories')),
-            (['--file', '-f'], dict(nargs='+', metavar='SCRIPT', default=None,
-                                    help='script to run in project directories')),
+            # (['--file', '-f'], dict(nargs='+', metavar='SCRIPT', default=None,
+            #                         help='script to run in project directories')),
             (['--ignore-errors', '-i'], dict(action='store_true', help='ignore errors in command or script')),
             (['--parallel'], dict(action='store_true', help='run commands in parallel')),
             (['--groups', '-g'], dict(choices=CLOWDER_CONTROLLER.get_all_group_names(),
@@ -65,18 +65,21 @@ class ForallController(ArgparseController):
     def _forall(self):
         """Clowder forall command private implementation"""
 
-        if self.app.pargs.command is not None:
-            forall_command(CLOWDER_CONTROLLER, self.app.pargs.command, self.app.pargs.ignore_errors,
-                           group_names=self.app.pargs.groups, project_names=self.app.pargs.projects,
-                           skip=self.app.pargs.skip, parallel=self.app.pargs.parallel)
-            return
-
-        if self.app.pargs.file is not None:
-            forall_script(CLOWDER_CONTROLLER, self.app.pargs.file, self.app.pargs.ignore_errors,
-                          group_names=self.app.pargs.groups, project_names=self.app.pargs.projects,
-                          skip=self.app.pargs.skip, parallel=self.app.pargs.parallel)
-            return
-
-        cprint(' - Missing --command/-c or --file/-f argument')
-        sys.exit(1)
+        forall_script(CLOWDER_CONTROLLER, self.app.pargs.command, self.app.pargs.ignore_errors,
+                      group_names=self.app.pargs.groups, project_names=self.app.pargs.projects,
+                      skip=self.app.pargs.skip, parallel=self.app.pargs.parallel)
+        # if self.app.pargs.command is not None:
+        #     forall_command(CLOWDER_CONTROLLER, self.app.pargs.command, self.app.pargs.ignore_errors,
+        #                    group_names=self.app.pargs.groups, project_names=self.app.pargs.projects,
+        #                    skip=self.app.pargs.skip, parallel=self.app.pargs.parallel)
+        #     return
+        #
+        # if self.app.pargs.file is not None:
+        #     forall_script(CLOWDER_CONTROLLER, self.app.pargs.file, self.app.pargs.ignore_errors,
+        #                   group_names=self.app.pargs.groups, project_names=self.app.pargs.projects,
+        #                   skip=self.app.pargs.skip, parallel=self.app.pargs.parallel)
+        #     return
+        #
+        # cprint(' - Missing --command/-c or --file/-f argument')
+        # sys.exit(1)
 

--- a/clowder/clowder/cli/forall_controller.py
+++ b/clowder/clowder/cli/forall_controller.py
@@ -5,16 +5,10 @@
 
 """
 
-import sys
-
 from cement.ext.ext_argparse import ArgparseController, expose
-from termcolor import cprint
 
 from clowder.cli.globals import CLOWDER_CONTROLLER
-from clowder.cli.parallel import (
-    forall_command,
-    forall_script
-)
+from clowder.cli.parallel import forall
 from clowder.cli.util import options_help_message
 from clowder.clowder_repo import print_clowder_repo_status
 from clowder.util.decorators import valid_clowder_yaml_required
@@ -35,9 +29,7 @@ class ForallController(ArgparseController):
         help='Run command or script in project directories',
         arguments=[
             (['--command', '-c'], dict(nargs='+', metavar='COMMAND', default=None,
-                                       help='command(s) to run in project directories')),
-            # (['--file', '-f'], dict(nargs='+', metavar='SCRIPT', default=None,
-            #                         help='script to run in project directories')),
+                                       help='command or script to run in project directories')),
             (['--ignore-errors', '-i'], dict(action='store_true', help='ignore errors in command or script')),
             (['--parallel'], dict(action='store_true', help='run commands in parallel')),
             (['--groups', '-g'], dict(choices=CLOWDER_CONTROLLER.get_all_group_names(),
@@ -65,21 +57,6 @@ class ForallController(ArgparseController):
     def _forall(self):
         """Clowder forall command private implementation"""
 
-        forall_script(CLOWDER_CONTROLLER, self.app.pargs.command, self.app.pargs.ignore_errors,
-                      group_names=self.app.pargs.groups, project_names=self.app.pargs.projects,
-                      skip=self.app.pargs.skip, parallel=self.app.pargs.parallel)
-        # if self.app.pargs.command is not None:
-        #     forall_command(CLOWDER_CONTROLLER, self.app.pargs.command, self.app.pargs.ignore_errors,
-        #                    group_names=self.app.pargs.groups, project_names=self.app.pargs.projects,
-        #                    skip=self.app.pargs.skip, parallel=self.app.pargs.parallel)
-        #     return
-        #
-        # if self.app.pargs.file is not None:
-        #     forall_script(CLOWDER_CONTROLLER, self.app.pargs.file, self.app.pargs.ignore_errors,
-        #                   group_names=self.app.pargs.groups, project_names=self.app.pargs.projects,
-        #                   skip=self.app.pargs.skip, parallel=self.app.pargs.parallel)
-        #     return
-        #
-        # cprint(' - Missing --command/-c or --file/-f argument')
-        # sys.exit(1)
-
+        forall(CLOWDER_CONTROLLER, self.app.pargs.command, self.app.pargs.ignore_errors,
+               group_names=self.app.pargs.groups, project_names=self.app.pargs.projects,
+               skip=self.app.pargs.skip, parallel=self.app.pargs.parallel)

--- a/clowder/clowder/cli/parallel.py
+++ b/clowder/clowder/cli/parallel.py
@@ -119,46 +119,13 @@ __clowder_pool__ = mp.Pool(initializer=worker_init)
 __clowder_progress__ = Progress()
 
 
-def forall_command(clowder, commands, ignore_errors, group_names, **kwargs):
-    """Runs command(s) in project directories specified
-
-    .. py:function:: forall_command(commands, ignore_errors, group_names, project_names=None, skip=[], parallel=False)
-
-    :param ClowderController clowder: ClowderController instance
-    :param list[str] commands: Commands to run
-    :param bool ignore_errors: Whether to exit if command returns a non-zero exit code
-    :param list[str] group_names: Group names to run command for
-
-    Keyword Args:
-        project_names (list[str]): Project names to clean
-        skip list[str]: Project names to skip
-        parallel bool: Whether command is being run in parallel, affects output
-    """
-
-    project_names = kwargs.get('project_names', None)
-    skip = kwargs.get('skip', [])
-    parallel = kwargs.get('parallel', False)
-
-    if project_names is None:
-        projects = filter_projects_on_group_names(clowder.groups, group_names)
-    else:
-        projects = filter_projects_on_project_names(clowder.groups, project_names)
-
-    if parallel:
-        _forall_parallel(commands, skip, ignore_errors, projects)
-        return
-
-    for project in projects:
-        run_project_command(project, skip, 'run', commands, ignore_errors)
-
-
-def forall_script(clowder, script_command, ignore_errors, group_names, **kwargs):
+def forall(clowder, command, ignore_errors, group_names, **kwargs):
     """Runs script in project directories specified
 
     .. py:function:: forall_script(script_command, ignore_errors, group_names, project_names=None, skip=[], parallel=False)
 
     :param ClowderController clowder: ClowderController instance
-    :param list[str] script_command: Script and optional arguments
+    :param list[str] command: Command or script and optional arguments
     :param bool ignore_errors: Whether to exit if command returns a non-zero exit code
     :param list[str] group_names: Group names to run command for
 
@@ -178,11 +145,11 @@ def forall_script(clowder, script_command, ignore_errors, group_names, **kwargs)
         projects = filter_projects_on_project_names(clowder.groups, project_names)
 
     if parallel:
-        _forall_parallel([" ".join(script_command)], skip, ignore_errors, projects)
+        _forall_parallel([" ".join(command)], skip, ignore_errors, projects)
         return
 
     for project in projects:
-        run_project_command(project, skip, 'run', [" ".join(script_command)], ignore_errors)
+        run_project_command(project, skip, 'run', [" ".join(command)], ignore_errors)
 
 
 def herd(clowder, group_names, **kwargs):

--- a/clowder/clowder/cli/parallel.py
+++ b/clowder/clowder/cli/parallel.py
@@ -119,10 +119,10 @@ __clowder_pool__ = mp.Pool(initializer=worker_init)
 __clowder_progress__ = Progress()
 
 
-def forall(clowder, commands, ignore_errors, group_names, **kwargs):
-    """Runs command or script in project directories specified
+def forall_command(clowder, commands, ignore_errors, group_names, **kwargs):
+    """Runs command(s) in project directories specified
 
-    .. py:function:: forall(command, ignore_errors, group_names, project_names=None, skip=[], parallel=False)
+    .. py:function:: forall_command(commands, ignore_errors, group_names, project_names=None, skip=[], parallel=False)
 
     :param ClowderController clowder: ClowderController instance
     :param list[str] commands: Commands to run
@@ -150,6 +150,39 @@ def forall(clowder, commands, ignore_errors, group_names, **kwargs):
 
     for project in projects:
         run_project_command(project, skip, 'run', commands, ignore_errors)
+
+
+def forall_script(clowder, script_command, ignore_errors, group_names, **kwargs):
+    """Runs script in project directories specified
+
+    .. py:function:: forall_script(script_command, ignore_errors, group_names, project_names=None, skip=[], parallel=False)
+
+    :param ClowderController clowder: ClowderController instance
+    :param list[str] script_command: Script and optional arguments
+    :param bool ignore_errors: Whether to exit if command returns a non-zero exit code
+    :param list[str] group_names: Group names to run command for
+
+    Keyword Args:
+        project_names (list[str]): Project names to clean
+        skip list[str]: Project names to skip
+        parallel bool: Whether command is being run in parallel, affects output
+    """
+
+    project_names = kwargs.get('project_names', None)
+    skip = kwargs.get('skip', [])
+    parallel = kwargs.get('parallel', False)
+
+    if project_names is None:
+        projects = filter_projects_on_group_names(clowder.groups, group_names)
+    else:
+        projects = filter_projects_on_project_names(clowder.groups, project_names)
+
+    if parallel:
+        _forall_parallel([" ".join(script_command)], skip, ignore_errors, projects)
+        return
+
+    for project in projects:
+        run_project_command(project, skip, 'run', [" ".join(script_command)], ignore_errors)
 
 
 def herd(clowder, group_names, **kwargs):

--- a/test/scripts/cats/forall.sh
+++ b/test/scripts/cats/forall.sh
@@ -34,8 +34,8 @@ test_forall_command() {
     print_single_separator
     echo "TEST: Run forall command"
     clowder forall $PARALLEL -c 'git status' || exit 1
-    echo "TEST: Run forall command with multiple arguments"
-    clowder forall $PARALLEL -c 'git status' 'echo "hi"'|| exit 1
+    # echo "TEST: Run forall command with multiple arguments"
+    # clowder forall $PARALLEL -c 'git status' 'echo "hi"'|| exit 1
     echo "TEST: Run forall command for specific groups"
     clowder forall $PARALLEL -c 'git status' -g "$@" || exit 1
     echo "TEST: Run forall command with error"
@@ -48,19 +48,19 @@ test_forall_command 'cats'
 test_forall_script() {
     print_single_separator
     echo "TEST: Run forall script"
-    clowder forall $PARALLEL -f "$TEST_SCRIPT_DIR/test_forall_script.sh" || exit 1
+    clowder forall $PARALLEL -c "$TEST_SCRIPT_DIR/test_forall_script.sh" || exit 1
     echo "TEST: Run forall script with arguments"
-    clowder forall $PARALLEL -f "$TEST_SCRIPT_DIR/test_forall_script_args.sh" "one" "two" || exit 1
+    clowder forall $PARALLEL -c "$TEST_SCRIPT_DIR/test_forall_script_args.sh" "one" "two" || exit 1
     echo "TEST: Fail running forall script with arguments"
-    clowder forall $PARALLEL -f "$TEST_SCRIPT_DIR/test_forall_script_args.sh" "one" && exit 1
+    clowder forall $PARALLEL -c "$TEST_SCRIPT_DIR/test_forall_script_args.sh" "one" && exit 1
     echo "TEST: Ignore failures running forall script with arguments"
-    clowder forall $PARALLEL -if "$TEST_SCRIPT_DIR/test_forall_script_args.sh" "one" || exit 1
+    clowder forall $PARALLEL -ic "$TEST_SCRIPT_DIR/test_forall_script_args.sh" "one" || exit 1
     echo "TEST: Run forall script for specific groups"
-    clowder forall $PARALLEL -f "$TEST_SCRIPT_DIR/test_forall_script.sh" -g "$@" || exit 1
+    clowder forall $PARALLEL -c "$TEST_SCRIPT_DIR/test_forall_script.sh" -g "$@" || exit 1
     echo "TEST: Run forall script with error"
-    clowder forall $PARALLEL -f "$TEST_SCRIPT_DIR/test_forall_script_error.sh" && exit 1
+    clowder forall $PARALLEL -c "$TEST_SCRIPT_DIR/test_forall_script_error.sh" && exit 1
     echo "TEST: Run forall script with --ignore-error"
-    clowder forall $PARALLEL -if "$TEST_SCRIPT_DIR/test_forall_script_error.sh" || exit 1
+    clowder forall $PARALLEL -ic "$TEST_SCRIPT_DIR/test_forall_script_error.sh" || exit 1
 }
 test_forall_script 'cats'
 
@@ -69,7 +69,7 @@ test_forall_projects() {
     echo "TEST: Run forall command for specific projects"
     clowder forall $PARALLEL -c 'git status' -p "$@" || exit 1
     echo "TEST: Run forall script for specific projects"
-    clowder forall $PARALLEL -f "$TEST_SCRIPT_DIR/test_forall_script.sh" -p "$@" || exit 1
+    clowder forall $PARALLEL -c "$TEST_SCRIPT_DIR/test_forall_script.sh" -p "$@" || exit 1
 }
 test_forall_projects 'jrgoodle/kit' 'jrgoodle/kishka'
 
@@ -78,10 +78,10 @@ test_forall_environment_variables() {
     echo "TEST: Test forall environment variables in script"
     clowder link
     clowder herd $PARALLEL || exit 1
-    clowder forall $PARALLEL -f "$TEST_SCRIPT_DIR/test_forall_script_env_kit.sh" -p "jrgoodle/kit" || exit 1
-    clowder forall $PARALLEL -f "$TEST_SCRIPT_DIR/test_forall_script_env_duke.sh" -p "jrgoodle/duke" || exit 1
-    clowder forall $PARALLEL -f "$TEST_SCRIPT_DIR/test_forall_script_env_duke.sh" && exit 1
-    clowder forall $PARALLEL -if "$TEST_SCRIPT_DIR/test_forall_script_env_duke.sh" || exit 1
+    clowder forall $PARALLEL -c "$TEST_SCRIPT_DIR/test_forall_script_env_kit.sh" -p "jrgoodle/kit" || exit 1
+    clowder forall $PARALLEL -c "$TEST_SCRIPT_DIR/test_forall_script_env_duke.sh" -p "jrgoodle/duke" || exit 1
+    clowder forall $PARALLEL -c "$TEST_SCRIPT_DIR/test_forall_script_env_duke.sh" && exit 1
+    clowder forall $PARALLEL -ic "$TEST_SCRIPT_DIR/test_forall_script_env_duke.sh" || exit 1
     echo "TEST: Test forall environment variables in command"
     clowder forall $PARALLEL -c 'if [ $PROJECT_NAME != jrgoodle/kit ]; then exit 1; fi' -p 'jrgoodle/kit' || exit 1
     clowder forall $PARALLEL -c 'if [ $PROJECT_REMOTE != origin ]; then exit 1; fi' -p 'jrgoodle/kit' || exit 1

--- a/test/scripts/cats/forall.sh
+++ b/test/scripts/cats/forall.sh
@@ -26,6 +26,7 @@ test_forall_branches() {
         test_branch v0.1
         popd || exit 1
     done
+    clowder herd $PARALLEL || exit 1
 }
 test_forall_branches
 
@@ -47,13 +48,19 @@ test_forall_command 'cats'
 test_forall_script() {
     print_single_separator
     echo "TEST: Run forall script"
-    clowder forall $PARALLEL -c "$TEST_SCRIPT_DIR/test_forall_script.sh" || exit 1
+    clowder forall $PARALLEL -f "$TEST_SCRIPT_DIR/test_forall_script.sh" || exit 1
+    echo "TEST: Run forall script with arguments"
+    clowder forall $PARALLEL -f "$TEST_SCRIPT_DIR/test_forall_script_args.sh" "one" "two" || exit 1
+    echo "TEST: Fail running forall script with arguments"
+    clowder forall $PARALLEL -f "$TEST_SCRIPT_DIR/test_forall_script_args.sh" "one" && exit 1
+    echo "TEST: Ignore failures running forall script with arguments"
+    clowder forall $PARALLEL -if "$TEST_SCRIPT_DIR/test_forall_script_args.sh" "one" || exit 1
     echo "TEST: Run forall script for specific groups"
-    clowder forall $PARALLEL -c "$TEST_SCRIPT_DIR/test_forall_script.sh" -g "$@" || exit 1
+    clowder forall $PARALLEL -f "$TEST_SCRIPT_DIR/test_forall_script.sh" -g "$@" || exit 1
     echo "TEST: Run forall script with error"
-    clowder forall $PARALLEL -c "$TEST_SCRIPT_DIR/test_forall_script_error.sh" && exit 1
+    clowder forall $PARALLEL -f "$TEST_SCRIPT_DIR/test_forall_script_error.sh" && exit 1
     echo "TEST: Run forall script with --ignore-error"
-    clowder forall $PARALLEL -ic "$TEST_SCRIPT_DIR/test_forall_script_error.sh" || exit 1
+    clowder forall $PARALLEL -if "$TEST_SCRIPT_DIR/test_forall_script_error.sh" || exit 1
 }
 test_forall_script 'cats'
 
@@ -62,7 +69,7 @@ test_forall_projects() {
     echo "TEST: Run forall command for specific projects"
     clowder forall $PARALLEL -c 'git status' -p "$@" || exit 1
     echo "TEST: Run forall script for specific projects"
-    clowder forall $PARALLEL -c "$TEST_SCRIPT_DIR/test_forall_script.sh" -p "$@" || exit 1
+    clowder forall $PARALLEL -f "$TEST_SCRIPT_DIR/test_forall_script.sh" -p "$@" || exit 1
 }
 test_forall_projects 'jrgoodle/kit' 'jrgoodle/kishka'
 
@@ -71,10 +78,10 @@ test_forall_environment_variables() {
     echo "TEST: Test forall environment variables in script"
     clowder link
     clowder herd $PARALLEL || exit 1
-    clowder forall $PARALLEL -c "$TEST_SCRIPT_DIR/test_forall_script_env_kit.sh" -p "jrgoodle/kit" || exit 1
-    clowder forall $PARALLEL -c "$TEST_SCRIPT_DIR/test_forall_script_env_duke.sh" -p "jrgoodle/duke" || exit 1
-    clowder forall $PARALLEL -c "$TEST_SCRIPT_DIR/test_forall_script_env_duke.sh" && exit 1
-    clowder forall $PARALLEL -ic "$TEST_SCRIPT_DIR/test_forall_script_env_duke.sh" || exit 1
+    clowder forall $PARALLEL -f "$TEST_SCRIPT_DIR/test_forall_script_env_kit.sh" -p "jrgoodle/kit" || exit 1
+    clowder forall $PARALLEL -f "$TEST_SCRIPT_DIR/test_forall_script_env_duke.sh" -p "jrgoodle/duke" || exit 1
+    clowder forall $PARALLEL -f "$TEST_SCRIPT_DIR/test_forall_script_env_duke.sh" && exit 1
+    clowder forall $PARALLEL -if "$TEST_SCRIPT_DIR/test_forall_script_env_duke.sh" || exit 1
     echo "TEST: Test forall environment variables in command"
     clowder forall $PARALLEL -c 'if [ $PROJECT_NAME != jrgoodle/kit ]; then exit 1; fi' -p 'jrgoodle/kit' || exit 1
     clowder forall $PARALLEL -c 'if [ $PROJECT_REMOTE != origin ]; then exit 1; fi' -p 'jrgoodle/kit' || exit 1

--- a/test/scripts/cats/forall.sh
+++ b/test/scripts/cats/forall.sh
@@ -33,6 +33,8 @@ test_forall_command() {
     print_single_separator
     echo "TEST: Run forall command"
     clowder forall $PARALLEL -c 'git status' || exit 1
+    echo "TEST: Run forall command with multiple arguments"
+    clowder forall $PARALLEL -c 'git status' 'echo "hi"'|| exit 1
     echo "TEST: Run forall command for specific groups"
     clowder forall $PARALLEL -c 'git status' -g "$@" || exit 1
     echo "TEST: Run forall command with error"

--- a/test/scripts/test_forall_script_args.sh
+++ b/test/scripts/test_forall_script_args.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+if [ -z "$1" ]; then
+    exit 1
+fi
+
+if [ "$1" != 'one' ]; then
+    exit 1
+fi
+
+if [ -z "$2" ]; then
+    exit 1
+fi
+
+if [ "$2" != 'two' ]; then
+    exit 1
+fi


### PR DESCRIPTION
resolves #352

### Changes proposed

- Allow `clowder forall -c` to accept multiple commands
- Add `--file/-f` option to `clowder forall` for running script with parameters