### PR TITLE
Add version lock to against cement 2.x

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,6 +1,6 @@
 argcomplete>=1.9.0
 awscli>=1.11.186
-cement>=2.10.2
+cement>=2.10.2,<3.0
 colorama>=0.3.9
 coverage>=4.4.2
 GitPython>=2.1.0


### PR DESCRIPTION
Cement 3.x makes a large number of changes and is currently incompatible.

Works around #400 
